### PR TITLE
feat: add hydrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ Options:
   --help  Show this message and exit.
 ```
 
+## HYDRATE
+
+To rehydrate messages from the API this command accepts a file with message IDs in the format of `$channel_name/$post_number`.
+Both input and output file are optional, if not given, `stdin` and `stdout` are used.
+
+Output data is JSONL, one message per line.
+
+```text
+Usage: tegracli hydrate [OPTIONS] [INPUT_FILE] [OUTPUT_FILE]
+
+  Hydrate a file with messages-ids.
+
+Options:
+  --help  Show this message and exit.
+```
+
+For example, to rehydrate message IDs:
+
+```bash
+echo test_channel/1234 | tegracli hydrate
+>> {"_":"Message","id": 1234, ... , "restriction_reason":[],"ttl_period":null}
+```
+
 ## GROUP INIT and GROUP RUN
 
 In order to support updatable  and long-running collections `tegracli` sports an *account group* feature which retrieves

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,4 +205,26 @@ def test_configure(runner: CliRunner, tmp_path: Path):
         assert Path("tegracli.conf.yml").exists()
 
 
+def test_hydrate(runner: CliRunner, tmp_path: Path):
+    """Should hydrate a list of ids."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as temp_dir:
+        conf_file = Path(temp_dir) / "tegracli.conf.yml"
+
+        with conf_file.open("w") as config:
+            yaml.dump(
+                {
+                    "api_id": 123456,
+                    "api_hash": "wahgi231kmdma91",
+                    "session_name": "test",
+                },
+                config,
+            )
+
+        test_messages = ["QlobalChange/12182", "QlobalChangeEspana/162"]
+
+        result = runner.invoke(cli, ["hydrate"], input="\n".join(test_messages))
+
+    assert result.exit_code == 0
+
+
 patcher.stop()


### PR DESCRIPTION
Adds a command to read message IDs from a file or stdin and requests them from the Telegram API.

Implements and closes #39.
