### PR TITLE
feat: add `all` keyword to `group run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,16 @@ tegracli-project/
     |- 10000001.jsonl
     |- 10000002.jsonl
 ```
-To run the project command your terminal to `tegracli group run my_group` to collect the latest post of the accounts you want to track.
+
+To run the project command your terminal to `tegracli group run my_group` to collect the latest post of the accounts you want to track. If you have multiple groups configured you can run all by running `tegracli group run all`. This interprets all subdirectories as valid groups. However, `tegracli` will fail if a subdirectory is not a valid group.
 
 ```text
 Usage: tegracli group run [OPTIONS] [GROUPS]...
 
-  load a group configuration and run the groups operations
+  Load a group configuration and run the groups operations.
+    
+  GROUPS are subdirectories with a valid group configuration.
+    If the special keyword all is given, all subdirectories are considered.
 ```
 
 ## Result File Format

--- a/tegracli/main.py
+++ b/tegracli/main.py
@@ -262,7 +262,11 @@ def reset(groups: Tuple[str]):
 @click.argument("groups", nargs=-1)
 @click.pass_context
 def run(ctx: click.Context, groups: Tuple[str]):
-    """Load a group configuration and run the groups operations."""
+    """Load a group configuration and run the groups operations.
+    
+    GROUPS are subdirectories with a valid group configuration.
+        If the special keyword all is given, all subdirectories are considered.
+    """
     client = ctx.obj["client"]
     with client:
         run_group(client, groups)
@@ -351,6 +355,9 @@ def _handle_group_member(member: str, conf: Group, client: TelegramClient) -> No
 def run_group(client: TelegramClient, groups: Tuple[str]):
     """Runs the required operations for the specified groups."""
     cwd = Path()
+
+    if groups == ("all", ):
+        groups = list(Path().glob("*/"))
 
     # iterate groups
     for group_name in groups:

--- a/tegracli/main.py
+++ b/tegracli/main.py
@@ -357,7 +357,13 @@ def run_group(client: TelegramClient, groups: Tuple[str]):
     cwd = Path()
 
     if groups == ("all", ):
-        groups = list(Path().glob("*/"))
+        groups = [
+            path
+            for path
+            in Path().iterdir()
+            if path.is_dir()
+            and not path.name.startswith(".")
+        ]
 
     # iterate groups
     for group_name in groups:


### PR DESCRIPTION
Adds the special keyword `all` to the `group run`-command which run the group in each non-hidden sub-directory.